### PR TITLE
Expand visitor information

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -491,7 +491,7 @@
         <h2>Hotels</h2>
         <p>Dundee is well supplied with hotels (budget to luxury), B&amp;Bs (Bed and breakfast guest houses), and rentals.</p>
         <p>Prices are very good compared to elsewhere in the UK.</p>
-        <p>Check back later for recommendations and conference deals.</p>
+        <p>The [Dundee City Region webpage for SotMEU](https://www.meetdundeecityregion.co.uk/attending/conferences/state-of-the-map-europe) links to a selection of accommodation options</p>
       </div>
 
       <!--

--- a/www/index.html
+++ b/www/index.html
@@ -441,7 +441,7 @@
 	  Tickets are generally available up to 27 weeks before travel.
           There will often be cheaper tickets if you buy them early.
           Try <a href="https://www.nationalrail.co.uk/" target="_blank">National Rail Enquiries</a>, <a href="https://www.thetrainline.com/" target="_blank">The Trainline</a>, or <a href="https://www.raileurope.com/" target="_blank">RailEurope</a>.
-          You <i>could</i> take the <a href="https://www.sleeper.scot/" target="_blank">Caledonian Sleeper</a> -- with a 10% discount available on conference ticket purchase -- and arrive bleary eyed on the day of the conference but it will not be much cheaper than travelling the day before and staying at a hotel.
+          A 10% discount for the <a href="https://www.sleeper.scot/" target="_blank">Caledonian Sleeper</a> is made available to SotMEU conference attendees upon ticket purchase.  Receipt of your Caledonian Sleeper ticket can be used in-person to purchase onwards travel with Scotrail at a 20% discount; some conditions apply - see the <a href="https://www.scotrail.co.uk/inspiration-hub/offers/discounts/caledonian-sleeper">Scotrail's discount information page</a> for more details.
         </p>
       </div>
 

--- a/www/index.html
+++ b/www/index.html
@@ -441,7 +441,7 @@
 	  Tickets are generally available up to 27 weeks before travel.
           There will often be cheaper tickets if you buy them early.
           Try <a href="https://www.nationalrail.co.uk/" target="_blank">National Rail Enquiries</a>, <a href="https://www.thetrainline.com/" target="_blank">The Trainline</a>, or <a href="https://www.raileurope.com/" target="_blank">RailEurope</a>.
-          You <i>could</i> take the <a href="https://www.sleeper.scot/" target="_blank">Caledonian Sleeper</a> and arrive bleary eyed on the day of the conference but it will not be much cheaper than travelling the day before and staying at a hotel.
+          You <i>could</i> take the <a href="https://www.sleeper.scot/" target="_blank">Caledonian Sleeper</a> -- with a 10% discount available on conference ticket purchase -- and arrive bleary eyed on the day of the conference but it will not be much cheaper than travelling the day before and staying at a hotel.
         </p>
       </div>
 


### PR DESCRIPTION
* :heavy_plus_sign: Dundee City Region hyperlink
* :heavy_plus_sign: Calendonian Sleeper discount information (both 10% for SotM.eu ticket purchases, and also separately the 20% discount with Scotrail for onward travel)

I haven't yet added the [suggested umap](https://github.com/osm-uk/sotm-eu-2025/issues/65#issuecomment-3273770072) - the content in that map looks good already, but the SotMEU2025 homepage already has a few varying types of in-place content to scroll up and down through, and I'm wary of making it trickier/more complicated to navigate.  I'll experiment a bit.